### PR TITLE
feat: add Claude Code, Codex CLI, Gemini CLI rule support

### DIFF
--- a/memory/docs/features/manage_rules/manage_rules_script_design.md
+++ b/memory/docs/features/manage_rules/manage_rules_script_design.md
@@ -9,7 +9,7 @@ This document outlines the design for a new Python script, `src/manage_rules.py`
 3.  **Target Project Rules Directory:** A folder named **`project_rules/`** *created inside* the Target Repo during installation. It holds project-specific rule files, copied from a chosen set in the Source Repository. **This folder is considered temporary by `clean-rules` but can be version-controlled if desired for manual restoration between `clean-rules` and `install` operations.**
 4.  **Target Memory Bank Directory:** A folder named **`memory/`** *created inside* the Target Repo during installation, holding project-specific memory documents, populated from the Source Repository's `memory_starters/`. **This folder should be version controlled within the Target Repo.**
 5.  **Target Tools Directory:** A folder named **`tools/`** *created inside* the Target Repo during installation, holding utility scripts or configurations, populated from the Source Repository's `tool_starters/`. **This folder should be version controlled within the Target Repo.**
-6.  **Target Platform Rules:** The generated, platform-specific rule directories/files (e.g., `.clinerules/`, `.cursor/rules/`, `.roo/`, `.windsurf/rules/`, `.github/copilot-instructions.md`) created *inside* the Target Repo by the `sync` command using `project_rules/` as input. **These folders/files should be added to the Target Repo's `.gitignore` file.**
+6.  **Target Platform Rules:** The generated, platform-specific rule directories/files (e.g., `.clinerules/`, `.cursor/rules/`, `.roo/`, `.windsurf/rules/`, `.github/copilot-instructions.md`, `CLAUDE.md`, `AGENTS.md`, `.gemini/GEMINI.md`) created *inside* the Target Repo by the `sync` command using `project_rules/` as input. **These folders/files should be added to the Target Repo's `.gitignore` file.**
 
 **3. Features & Advantages**
 
@@ -23,23 +23,23 @@ This document outlines the design for a new Python script, `src/manage_rules.py`
 
 **4. Specification: `manage_rules.py` Commands**
 
-*   **`install <target_repo_path> [--rule-set <name>] [--cursor] [--cline] [...] [--all]`**
+*   **`install <target_repo_path> [--rule-set <name>] [--cursor] [--cline] [--roo] [--windsurf] [--copilot] [--claude-code] [--codex-cli] [--gemini-cli] [--all]`**
     *   **Action:**
         1.  Copies the specified rule set (default: `light-spec`) from the Source Repository's `rule_sets/<rule-set-name>` directory into `<target_repo_path>/project_rules/`. If `project_rules/` already exists, it will be overwritten or cleared first to ensure a fresh copy of the chosen rule set. *(A warning should be issued if overwriting)*.
         2.  Copies the content of the Source Repository's `memory_starters/` directory into `<target_repo_path>/memory/`. If `memory/` exists, new starter files from the source will be copied if they don't exist in the target; existing files in the target `memory/` will **not** be overwritten.
         3.  Copies the content of the Source Repository's `tool_starters/` directory into `<target_repo_path>/tools/`. If `tools/` exists, new starter files/subdirectories from the source will be copied if they don't exist in the target; existing files/subdirectories in the target `tools/` will **not** be overwritten.
         4.  Copies `env.example` and `requirements.txt` from the Source Repository's root to `<target_repo_path>/env.example` and `<target_repo_path>/requirements.txt`. If `env.example` / `requirements.txt` already exists in the target, it will **not** be overwritten.
         5.  Immediately runs the `sync` logic for the selected assistants. **If no assistant flags are provided, it defaults to generating rules for ALL supported assistants.**
-    *   **Output:** Prints progress messages. Suggests adding generated platform rule directories/files (including `.github/copilot-instructions.md`) to `.gitignore`. Recommends committing `memory/`, `tools/`, `env.example`, and `requirements.txt` to version control. Informs the user that `project_rules/` will be managed by the script (and removed by `clean-rules`).
+    *   **Output:** Prints progress messages. Suggests adding generated platform rule directories/files (including `.github/copilot-instructions.md`, `CLAUDE.md`, `AGENTS.md`, `.gemini/GEMINI.md`) to `.gitignore`. Recommends committing `memory/`, `tools/`, `env.example`, and `requirements.txt` to version control. Informs the user that `project_rules/` will be managed by the script (and removed by `clean-rules`).
 
-*   **`sync <target_repo_path> [--cursor] [--cline] [...] [--all]`**
+*   **`sync <target_repo_path> [--cursor] [--cline] [--roo] [--windsurf] [--copilot] [--claude-code] [--codex-cli] [--gemini-cli] [--all]`**
     *   **Action:** Reads rules from `<target_repo_path>/project_rules/`. For each selected assistant, it deletes the existing Target Platform Rules and regenerates them. **If no assistant flags are provided, it defaults to syncing ALL supported assistants.**
     *   **Use Case:** Run after manually modifying files within `<target_repo_path>/project_rules/` to update the generated rules for one, some, or all assistants.
     *   **Output:** Prints progress messages.
 
 *   **`clean-rules <target_repo_path>`**
     *   **Action:**
-        1.  Removes the generated Target Platform Rules directories/files (e.g., `.clinerules/`, `.cursor/rules/`, `.roo/`, `.windsurf/rules/`, `.github/copilot-instructions.md`) from `<target_repo_path>`. If `.github/copilot-instructions.md` is the only file in `.github/`, the `.github/` directory may also be removed.
+        1.  Removes the generated Target Platform Rules directories/files (e.g., `.clinerules/`, `.cursor/rules/`, `.roo/`, `.windsurf/rules/`, `.github/copilot-instructions.md`, `CLAUDE.md`, `AGENTS.md`, `.gemini/GEMINI.md`) from `<target_repo_path>`. If `.github/copilot-instructions.md` or `.gemini/GEMINI.md` is the only file in its directory, the directory may also be removed.
         2.  Removes the **`project_rules/`** directory itself from `<target_repo_path>`.
         3.  The `memory/` and `tools/` directories are **NOT** removed.
     *   **Use Case:** Remove all rule-related files (both generated and their sources) to allow for a fresh `install` of a different rule set or to revert to a clean state without rules, while preserving the project memory bank and tools.
@@ -47,7 +47,7 @@ This document outlines the design for a new Python script, `src/manage_rules.py`
 
 *   **`clean-all <target_repo_path>`**
     *   **Action:** Removes all framework components from `<target_repo_path>`:
-        1.  The generated Target Platform Rules directories/files (including the `.github/` directory if it was created/managed by this script for `copilot-instructions.md`).
+        1.  The generated Target Platform Rules directories/files (including the `.github/` or `.gemini/` directories if they were created/managed by this script for `copilot-instructions.md` or `GEMINI.md`).
         2.  The `project_rules/` directory.
         3.  The `memory/` directory.
         4.  The `tools/` directory. The `env.example` and `requirements.txt` file (environment for tools).
@@ -69,8 +69,8 @@ This document outlines the design for a new Python script, `src/manage_rules.py`
 *   `install`: Ensure non-destructive copying for `memory/`, `tools/`, `env.example`, and `requirements.txt`. Ensure `project_rules/` is freshly populated from the chosen rule set (e.g., clear and copy, or overwrite with warning).
 *   `clean-all`: **Must** include a user confirmation step.
 *   Directory names for framework components (e.g., `rule_sets` in source, `project_rules`, `memory`, `tools` in target, `memory_starters`, `tool_starters` in source) will be hardcoded as constants within the script.
-*   The `concatenate_ordered_files` helper function should ensure parent directories for the destination file are created (e.g., `.github/` for `copilot-instructions.md`).
-*   Cleanup logic for `clean-rules` and `clean-all` should attempt to remove the `.github/` directory if `copilot-instructions.md` was the only file managed by this script within it and the directory becomes empty.
+*   The `concatenate_ordered_files` helper function should ensure parent directories for the destination file are created (e.g., `.github/` for `copilot-instructions.md`, `.gemini/` for `GEMINI.md`).
+*   Cleanup logic for `clean-rules` and `clean-all` should attempt to remove the `.github/` and `.gemini/` directories if their respective rule files were the only files managed by this script within them and the directories become empty.
 
 **6. Initial Documentation Approach (Task 6.a)**
 
@@ -82,6 +82,6 @@ This document outlines the design for a new Python script, `src/manage_rules.py`
 4.  Explain that `project_rules/` is populated by `install` (from a chosen rule set) and removed by `clean-rules`. Advanced users *could* modify it before running `sync` but should be aware it's not preserved by `clean-rules`.
 5.  Document behaviors of `clean-rules` (removes generated rules and `project_rules/`) and `clean-all` (removes everything, with confirmation).
 6.  Explain how `install` handles pre-existing `memory/` and `tools/` directories (non-overwriting, only adds new starter files).
-7.  Document support for GitHub Copilot via `.github/copilot-instructions.md` generation.
+7.  Document support for GitHub Copilot, Claude Code, Codex CLI, and Gemini CLI via `.github/copilot-instructions.md`, `CLAUDE.md`, `AGENTS.md`, and `.gemini/GEMINI.md` generation.
 8.  Defer detailed guides on writing custom rules (beyond choosing a rule set via `install`) for later.
 9.  **Note:** This script now assumes compatibility with Windsurf versions that use the `.windsurf/rules/` structure for loading workspace rules. Users on older versions may need to update Windsurf.

--- a/src/rulebook_ai/assistants.py
+++ b/src/rulebook_ai/assistants.py
@@ -84,6 +84,33 @@ SUPPORTED_ASSISTANTS: List[AssistantSpec] = [
         filename='copilot-instructions.md',
         clean_path='.github/copilot-instructions.md'
     ),
+    AssistantSpec(
+        name='claude-code',
+        display_name='Claude Code',
+        rule_path='.',
+        is_multi_file=False,
+        supports_subdirectories=False,
+        filename='CLAUDE.md',
+        clean_path='CLAUDE.md'
+    ),
+    AssistantSpec(
+        name='codex-cli',
+        display_name='Codex CLI',
+        rule_path='.',
+        is_multi_file=False,
+        supports_subdirectories=False,
+        filename='AGENTS.md',
+        clean_path='AGENTS.md'
+    ),
+    AssistantSpec(
+        name='gemini-cli',
+        display_name='Gemini CLI',
+        rule_path='.gemini',
+        is_multi_file=False,
+        supports_subdirectories=False,
+        filename='GEMINI.md',
+        clean_path='.gemini/GEMINI.md'
+    ),
 ]
 
 # For quick lookups

--- a/src/rulebook_ai/core.py
+++ b/src/rulebook_ai/core.py
@@ -234,14 +234,14 @@ class RuleManager:
             if path_to_clean.is_file() and path_to_clean.exists():
                 path_to_clean.unlink()
                 print(f"- Removed: {path_to_clean}")
-                # Attempt to remove parent if it's an empty .github dir
-                if spec.name == 'copilot':
-                    try:
-                        if not any(path_to_clean.parent.iterdir()):
-                            path_to_clean.parent.rmdir()
-                            print(f"- Removed empty directory: {path_to_clean.parent}")
-                    except OSError:
-                        pass # Ignore if not empty or other error
+                # Attempt to remove empty parent directories (e.g., .github, .gemini)
+                try:
+                    parent = path_to_clean.parent
+                    if parent != target_root and not any(parent.iterdir()):
+                        parent.rmdir()
+                        print(f"- Removed empty directory: {parent}")
+                except OSError:
+                    pass  # Ignore if not empty or other error
             elif path_to_clean.is_dir() and path_to_clean.exists():
                 shutil.rmtree(path_to_clean)
                 print(f"- Removed: {path_to_clean}")

--- a/tests/integration/test_cli_commands.py
+++ b/tests/integration/test_cli_commands.py
@@ -43,11 +43,16 @@ def test_install_default_rule_set(script_runner, tmp_path):
     assert (tmp_target_repo_root / ".windsurf" / "rules").is_dir()
     gh_copilot_instructions_file = tmp_target_repo_root / ".github" / "copilot-instructions.md"
     assert gh_copilot_instructions_file.is_file()
+    assert (tmp_target_repo_root / "CLAUDE.md").is_file()
+    assert (tmp_target_repo_root / "AGENTS.md").is_file()
+    assert (tmp_target_repo_root / ".gemini" / "GEMINI.md").is_file()
 
     # Check content of a generated file to ensure it's from the correct source rules
     expected_content = "Meta-Rules for AI Assistant Interaction"
     gh_copilot_content = gh_copilot_instructions_file.read_text()
     assert expected_content in gh_copilot_content
+    claude_content = (tmp_target_repo_root / "CLAUDE.md").read_text()
+    assert expected_content in claude_content
 
     # 6. Check for .env.example and requirements.txt
     assert (tmp_target_repo_root / ".env.example").is_file()
@@ -68,6 +73,9 @@ def test_install_specific_rule_set(script_runner, tmp_path):
 
     gh_copilot_content = (tmp_target_repo_root / ".github" / "copilot-instructions.md").read_text()
     assert "Meta-Rules for AI Assistant Interaction" in gh_copilot_content
+    assert (tmp_target_repo_root / "CLAUDE.md").is_file()
+    assert (tmp_target_repo_root / "AGENTS.md").is_file()
+    assert (tmp_target_repo_root / ".gemini" / "GEMINI.md").is_file()
 
 
 def test_sync_after_manual_project_rules_modification(script_runner, tmp_path):
@@ -91,6 +99,12 @@ def test_sync_after_manual_project_rules_modification(script_runner, tmp_path):
     gh_copilot_file_path = tmp_target_repo_root / ".github" / "copilot-instructions.md"
     assert gh_copilot_file_path.is_file()
     assert modified_content in gh_copilot_file_path.read_text()
+    claude_path = tmp_target_repo_root / "CLAUDE.md"
+    codex_path = tmp_target_repo_root / "AGENTS.md"
+    gemini_path = tmp_target_repo_root / ".gemini" / "GEMINI.md"
+    for path in [claude_path, codex_path, gemini_path]:
+        assert path.is_file()
+        assert modified_content in path.read_text()
 
 
 def test_clean_rules_removes_rules_and_generated_keeps_memory_tools(script_runner, tmp_path):
@@ -108,6 +122,9 @@ def test_clean_rules_removes_rules_and_generated_keeps_memory_tools(script_runne
     assert not (tmp_target_repo_root / ".clinerules").exists()
     assert not (tmp_target_repo_root / ".roo").exists()
     assert not (tmp_target_repo_root / ".github").exists()
+    assert not (tmp_target_repo_root / "CLAUDE.md").exists()
+    assert not (tmp_target_repo_root / "AGENTS.md").exists()
+    assert not (tmp_target_repo_root / ".gemini").exists()
 
     assert (tmp_target_repo_root / TARGET_MEMORY_BANK_DIR).is_dir()
     assert (tmp_target_repo_root / TARGET_TOOLS_DIR).is_dir()
@@ -131,6 +148,9 @@ def test_clean_all_with_confirmation_yes(script_runner, tmp_path):
     assert not (tmp_target_repo_root / ".roo").exists()
     assert not (tmp_target_repo_root / ".windsurf").exists()
     assert not (tmp_target_repo_root / ".github").exists()
+    assert not (tmp_target_repo_root / "CLAUDE.md").exists()
+    assert not (tmp_target_repo_root / "AGENTS.md").exists()
+    assert not (tmp_target_repo_root / ".gemini").exists()
     assert not (tmp_target_repo_root / ".env.example").exists()
     assert not (tmp_target_repo_root / "requirements.txt").exists()
 
@@ -149,6 +169,9 @@ def test_clean_all_with_confirmation_no(script_runner, tmp_path):
     assert (tmp_target_repo_root / ".env.example").is_file()
     assert (tmp_target_repo_root / "requirements.txt").is_file()
     assert (tmp_target_repo_root / ".windsurf" / "rules").is_dir()
+    assert (tmp_target_repo_root / "CLAUDE.md").is_file()
+    assert (tmp_target_repo_root / "AGENTS.md").is_file()
+    assert (tmp_target_repo_root / ".gemini" / "GEMINI.md").is_file()
     assert "Clean-all operation cancelled by user." in result.stdout
 
 
@@ -179,7 +202,10 @@ def test_install_with_specific_assistant_flags(script_runner, tmp_path):
     assert not (tmp_target_repo_root / ".cursor").exists()
     assert not (tmp_target_repo_root / ".clinerules").exists()
     assert not (tmp_target_repo_root / ".roo").exists()
-    
+    assert not (tmp_target_repo_root / ".github").exists()
+    assert not (tmp_target_repo_root / "CLAUDE.md").exists()
+    assert not (tmp_target_repo_root / "AGENTS.md").exists()
+    assert not (tmp_target_repo_root / ".gemini").exists()
     # Should still create generic directories
     assert (tmp_target_repo_root / TARGET_PROJECT_RULES_DIR).is_dir()
     assert (tmp_target_repo_root / TARGET_MEMORY_BANK_DIR).is_dir()
@@ -199,6 +225,10 @@ def test_install_with_all_assistants_flag(script_runner, tmp_path):
     assert (tmp_target_repo_root / ".clinerules").is_dir()
     assert (tmp_target_repo_root / ".roo" / "rules").is_dir()
     assert (tmp_target_repo_root / ".windsurf" / "rules").is_dir()
+    assert (tmp_target_repo_root / ".github" / "copilot-instructions.md").is_file()
+    assert (tmp_target_repo_root / "CLAUDE.md").is_file()
+    assert (tmp_target_repo_root / "AGENTS.md").is_file()
+    assert (tmp_target_repo_root / ".gemini" / "GEMINI.md").is_file()
 
 
 def test_sync_with_specific_assistant_flags(script_runner, tmp_path):
@@ -250,3 +280,6 @@ def test_sync_detects_existing_assistants(script_runner, tmp_path):
     synced_cursor_rule_file = tmp_target_repo_root / ".cursor" / "rules" / "01-meta-rules.mdc"
     assert synced_cursor_rule_file.is_file()
     assert modified_content in synced_cursor_rule_file.read_text()
+    claude_file = tmp_target_repo_root / "CLAUDE.md"
+    assert claude_file.is_file()
+    assert modified_content in claude_file.read_text()


### PR DESCRIPTION
## Summary
- define new Claude Code, Codex CLI, and Gemini CLI assistants with dedicated rule file paths
- handle cleanup of assistant files and empty parent directories generically
- test and document new assistant support in manage_rules design and CLI flows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b12db72378832f9fc4fa208188a8c8