### PR TITLE
feat: add ruleset rating command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 # Rulebook-AI: Universal Rules Template for AI Coding Assistants
 
 * Bugs or ideas → open an **Issue** in the repo (run `rulebook-ai bug-report`)
+* Rate or review rule sets → run `rulebook-ai rate-ruleset`
+* See rule set reviews before installing → run `rulebook-ai list-rules` and follow the link
 * Anonymous feedback: [Go to the Google Form](https://docs.google.com/forms/d/e/1FAIpQLSeW57QtPEWIRhHY1iOb8f5KQZTGLSeeb_PN2iZLd0Aw_pVYxw/viewform?usp=header)
 
 ## Quick Start with uv/uvx
@@ -107,6 +109,7 @@ This template repository serves as the central source for master rule sets. To u
 
 1.  **List Available Rule Sets (Optional):**
     *   Use the `list-rules` command to see which rule sets are available for installation from this Source Template Repo.
+    *   **Note:** The command also prints a link to the ratings & reviews wiki so you can read feedback before installing.
     *   **Command:**
         ```bash
         rulebook-ai list-rules
@@ -145,6 +148,9 @@ uvx rulebook-ai doctor
 
 # Clean up rules
 uvx rulebook-ai clean-rules --project-dir /path/to/your/project
+
+# Rate or review rule sets
+uvx rulebook-ai rate-ruleset
 
 # Report a bug in rulebook-ai
 uvx rulebook-ai bug-report

--- a/memory/docs/features/manage_rules/manage_rules_script_design.md
+++ b/memory/docs/features/manage_rules/manage_rules_script_design.md
@@ -58,12 +58,17 @@ This document outlines the design for a new Python script, `src/manage_rules.py`
 *   **`list-rules`**
     *   **Action:** Scans the Source Repository's `rule_sets/` directory. It lists all subdirectories found within `rule_sets/`, as each subdirectory represents an available rule set.
     *   **Use Case:** Allows users to quickly see which rule sets are available for installation without needing to manually inspect the `rule_sets/` directory in the source framework.
-    *   **Output:** Prints a header like "Available rule sets:" followed by the name of each discovered rule set, one per line. If no rule sets are found, it prints an appropriate message.
+    *   **Output:** Prints a header like "Available rule sets:" followed by the name of each discovered rule set, one per line. If no rule sets are found, it prints an appropriate message. The command also shows a link to the Ratings & Reviews wiki so users can read or leave feedback.
 
 *   **`bug-report`**
     *   **Action:** Prints the GitHub issue tracker URL and attempts to open it in the user's default browser.
     *   **Use Case:** Provides a quick way for users to report problems with the tool.
     *   **Output:** Shows the issue tracker link.
+
+*   **`rate-ruleset`**
+    *   **Action:** Prints the ratings and reviews wiki URL and attempts to open it in the user's default browser.
+    *   **Use Case:** Directs users to rate existing rule sets or read community feedback.
+    *   **Output:** Shows the ratings and reviews link.
 
 **5. Implementation Notes**
 

--- a/memory/docs/features/manage_rules/refactoring_plan.md
+++ b/memory/docs/features/manage_rules/refactoring_plan.md
@@ -59,4 +59,8 @@ Following the refactor, the specification was extended to include Claude Code, C
 
 An additional enhancement introduced a `bug-report` CLI command that links users to the project's issue tracker for submitting problems.
 
+Another enhancement added a `rate-ruleset` CLI command that opens the Ratings & Reviews wiki, encouraging community feedback on rule sets.
+
+An additional improvement surfaces the Ratings & Reviews wiki link within the `list-rules` command so users can read feedback before installing a ruleset.
+
 A subsequent enhancement introduced support for mode-based assistants (Kilo Code, Roo Code), which required adding a `has_modes` flag to the `AssistantSpec` and extending the `RuleManager` engine. This demonstrated the extensibility of the refactored architecture.

--- a/memory/docs/features/manage_rules/task_plan.md
+++ b/memory/docs/features/manage_rules/task_plan.md
@@ -64,3 +64,14 @@ This plan is a historical record of the tasks completed, based on the final desi
 | **E8** | Update unit and integration tests to verify the new mode-based logic and assistant support. | P1 | Completed | E7 |
 | **E9** | Enhance integration tests to check for multiple sub-modes and files within them. | P2 | Completed | E8 |
 | **E10** | Update design documents to reflect Kilo Code and Warp support. | P2 | Completed | E7 |
+
+### Enhancement: Ratings & Reviews Command
+
+**Description:** Introduced a utility command that directs users to the project's Ratings & Reviews wiki for rule sets.
+
+| Task ID | Description | Importance | Status | Dependencies |
+|:--------|:------------|:-----------|:-------|:-------------|
+| **E11** | Add `rate-ruleset` CLI command linking to the ratings wiki. | P3 | Completed | - |
+| **E12** | Update design docs and tests for ratings command. | P3 | Completed | E11 |
+| **E13** | Surface ratings wiki link in `list-rules` output. | P3 | Completed | E11 |
+| **E14** | Update docs and tests for ratings link in `list-rules`. | P3 | Completed | E13 |

--- a/src/rulebook_ai/cli.py
+++ b/src/rulebook_ai/cli.py
@@ -49,9 +49,16 @@ def create_parser() -> argparse.ArgumentParser:
     clean_all_parser.add_argument("--project-dir", "-p", help="Target project directory (default: current directory)")
     
     # --- Utility Commands ---
-    subparsers.add_parser("list-rules", help="List available rule sets.")
+    subparsers.add_parser(
+        "list-rules",
+        help="List available rule sets and show ratings link.",
+    )
     subparsers.add_parser("doctor", help="Check environment and setup for issues.")
     subparsers.add_parser("bug-report", help="Open the project issue tracker to report a bug.")
+    subparsers.add_parser(
+        "rate-ruleset",
+        help="Open the ratings & reviews wiki page for rulesets.",
+    )
 
     return parser
 
@@ -101,6 +108,9 @@ def handle_command(args: argparse.Namespace) -> int:
 
     elif command == "bug-report":
         return rule_manager.report_bug()
+
+    elif command == "rate-ruleset":
+        return rule_manager.rate_ruleset()
 
     return 1
 

--- a/src/rulebook_ai/core.py
+++ b/src/rulebook_ai/core.py
@@ -29,6 +29,9 @@ SOURCE_ENV_EXAMPLE_FILE = ".env.example"
 SOURCE_REQUIREMENTS_TXT_FILE = "requirements.txt"
 
 BUG_REPORT_URL = "https://github.com/botingw/rulebook-ai/issues"
+RATINGS_REVIEWS_URL = (
+    "https://github.com/botingw/rulebook-ai/wiki/Ratings-%26-Reviews-(Rulesets)"
+)
 
 
 class RuleManager:
@@ -297,12 +300,22 @@ class RuleManager:
         print("Available rule sets:")
         for p in sorted([p.name for p in self.source_rules_dir.iterdir() if p.is_dir() and not p.name.startswith('.')]):
             print(f"  - {p}")
+        print(f"\nFor ratings and reviews of these rule sets, visit {RATINGS_REVIEWS_URL}")
 
     def report_bug(self) -> int:
         """Provide the project issue tracker URL for reporting bugs."""
         print(f"To report a bug, please visit {BUG_REPORT_URL}")
         try:
             webbrowser.open(BUG_REPORT_URL)
+        except Exception:
+            pass
+        return 0
+
+    def rate_ruleset(self) -> int:
+        """Open the ratings and reviews wiki page for rulesets."""
+        print(f"For ratings and reviews, please visit {RATINGS_REVIEWS_URL}")
+        try:
+            webbrowser.open(RATINGS_REVIEWS_URL)
         except Exception:
             pass
         return 0

--- a/tests/integration/test_cli_commands.py
+++ b/tests/integration/test_cli_commands.py
@@ -223,6 +223,7 @@ def test_list_rules(script_runner):
     assert "Available rule sets:" in stdout
     assert "- heavy-spec" in stdout
     assert "- light-spec" in stdout
+    assert "https://github.com/botingw/rulebook-ai/wiki/Ratings-%26-Reviews-(Rulesets)" in stdout
     
 
 def test_install_with_specific_assistant_flags(script_runner, tmp_path):
@@ -333,3 +334,13 @@ def test_bug_report_command(script_runner):
     result = script_runner(["bug-report"])
     assert result.returncode == 0, f"Command failed. STDERR:\n{result.stderr}"
     assert "https://github.com/botingw/rulebook-ai/issues" in result.stdout
+
+
+def test_rate_ruleset_command(script_runner):
+    """Verify the rate-ruleset command opens the ratings page URL."""
+    result = script_runner(["rate-ruleset"])
+    assert result.returncode == 0, f"Command failed. STDERR:\n{result.stderr}"
+    assert (
+        "https://github.com/botingw/rulebook-ai/wiki/Ratings-%26-Reviews-(Rulesets)"
+        in result.stdout
+    )


### PR DESCRIPTION
## Summary
- add `rate-ruleset` CLI command that opens the Ratings & Reviews wiki
- document new command and usage
- test the new rate-ruleset command
- document ratings command in manage_rules design docs
- show Ratings & Reviews link when listing rule sets

## Testing
- `pre-commit run --files README.md memory/docs/features/manage_rules/manage_rules_script_design.md memory/docs/features/manage_rules/refactoring_plan.md memory/docs/features/manage_rules/task_plan.md src/rulebook_ai/cli.py src/rulebook_ai/core.py tests/integration/test_cli_commands.py` *(fails: error: RPC failed; HTTP 403)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b73f148dc4832fa12c8332b3f35944