### PR TITLE
docs: expand sync conflict resolution

### DIFF
--- a/memory/docs/features/manage_rules/ADR-002_Scoped_Sync_and_Cleanup.md
+++ b/memory/docs/features/manage_rules/ADR-002_Scoped_Sync_and_Cleanup.md
@@ -1,0 +1,26 @@
+# ADR-002: Scoped Sync and Pack Cleanup
+
+## Status
+Accepted
+
+## Context
+`rulebook-ai` is moving from a single ruleset model to composable packs. The original CLI coupled pack operations with a global `sync` that updated every assistant and left stale `memory/` and `tools/` files when packs were removed. This produced surprises for users and inconsistent project state.
+
+## Decision
+- `add_pack` and `remove_pack` only mutate the active pack list and then invoke `sync` in *implicit* mode.
+- `sync` supports two modes:
+  - **Explicit** – users run `rulebook-ai sync --cursor --claude` to target specific assistants.
+  - **Implicit** – internal calls without assistant flags rebuild rules only for assistants already present in the repository.
+- During sync, the system records which `memory/` and `tools/` files originate from each pack. Removing a pack purges these files before rebuilding from remaining packs.
+- Implicit sync never creates rule directories for new assistants; it updates only those previously configured.
+- Two cleanup commands remain: `clean` (remove all packs, memory, tools, and rules) and `clean-rules` (delete only `.rulebook-ai/` and generated rules).
+
+## Consequences
+- Users avoid accidental propagation of rules to new assistants.
+- Projects stay consistent after pack removal because stale files are tracked and deleted.
+- Tracking per-pack file maps introduces a small bookkeeping cost.
+
+## Alternatives Considered
+- Running a full sync on every `add/remove` regardless of existing assistants – rejected due to surprise updates.
+- Requiring users to run `sync` manually after every pack change – rejected because it leaves the repo in an inconsistent state by default.
+

--- a/memory/docs/features/manage_rules/command_flow_diagrams.md
+++ b/memory/docs/features/manage_rules/command_flow_diagrams.md
@@ -1,0 +1,73 @@
+# Command Flow Diagrams
+
+This document visualizes the high-level flow of major commands introduced in the composable pack system. Diagrams focus on
+spec-level behavior rather than implementation details.
+
+## `rulebook-ai packs add <name>`
+
+```mermaid
+flowchart TD
+    A[User runs `packs add <name>`] --> B{Pack exists in source repo?}
+    B -- No --> Z[Abort with error]
+    B -- Yes --> C[Copy pack to `.rulebook-ai/packs/`]
+    C --> D[Record name & version in `selection.json`]
+    D --> E[Invoke implicit `sync` (see `sync` diagram)]
+    E --> F[Command completes]
+```
+
+*`packs add` triggers an implicit `sync`; see the `sync` command diagram for how rules, memory, and tools are regenerated.*
+
+## `rulebook-ai packs remove <name>`
+
+```mermaid
+flowchart TD
+    A[User runs `packs remove <name>`] --> B{Pack active?}
+    B -- No --> Z[Abort with error]
+    B -- Yes --> C[Remove entry from `selection.json`]
+    C --> D[Delete pack from `.rulebook-ai/packs/`]
+    D --> E[Purge pack files from `memory/` & `tools/`]
+    E --> F[Invoke implicit `sync` (see `sync` diagram)]
+    F --> G[Command completes]
+```
+
+*`packs remove` triggers an implicit `sync`; see the `sync` command diagram for how remaining packs are rebuilt.*
+
+## `rulebook-ai sync`
+
+```mermaid
+flowchart TD
+    A[User runs `sync` (optional flags)] --> B{Assistant flags provided?}
+    B -- Yes --> C[Explicit mode: target listed assistants]
+    B -- No --> D[Implicit mode: detect existing rule dirs]
+    C --> E[Delete generated rules for targets]
+    D --> E
+    E --> F[Merge active packs into `memory/` & `tools/`]
+    F --> G[Warn on conflicts or abort in `--strict` mode]
+    G --> H[Generate combined rules for targeted assistants]
+    H --> I[Command completes]
+```
+
+## `rulebook-ai clean`
+
+```mermaid
+flowchart TD
+    A[User runs `clean`] --> B{User confirms?}
+    B -- No --> Z[Abort]
+    B -- Yes --> C[Delete `.rulebook-ai/`]
+    C --> D[Delete `memory/` & `tools/`]
+    D --> E[Delete generated assistant rule dirs]
+    E --> F[Command completes]
+```
+
+## `rulebook-ai clean-rules`
+
+```mermaid
+flowchart TD
+    A[User runs `clean-rules`] --> B{User confirms?}
+    B -- No --> Z[Abort]
+    B -- Yes --> C[Delete `.rulebook-ai/`]
+    C --> D[Delete generated assistant rule dirs]
+    D --> E[Preserve `memory/` & `tools/`]
+    E --> F[Command completes]
+```
+

--- a/memory/docs/features/manage_rules/support_flexible_ruleset_plan.md
+++ b/memory/docs/features/manage_rules/support_flexible_ruleset_plan.md
@@ -2,6 +2,8 @@
 
 This document provides the canonical implementation plan for refactoring `rulebook-ai` to a composable "Pack" model. It combines the high-level architectural vision with a detailed, phased roadmap for developers.
 
+Commands not covered here—such as `bug-report` or `rate-ruleset`—retain their legacy behavior documented in [`spec.md`](spec.md).
+
 ## 1. First Principles
 
 *   **AI Context is King:** The primary goal is to create a unified, rich, and accessible context for the AI assistant in the target project's `memory/` and `tools/` directories.
@@ -66,13 +68,13 @@ your-target-project/
 └── .cursor/                    # Generated platform rules (gitignored)
 ```
 
-**`selection.json` Specification:**
+**`selection.json` Specification:** Each entry records the pack's name and version.
 
 ```json
 {
   "packs": [
-    "light-spec",
-    "python-data-scientist"
+    { "name": "light-spec", "version": "1.0.0" },
+    { "name": "python-data-scientist", "version": "2.3.0" }
   ]
 }
 ```
@@ -84,11 +86,12 @@ your-target-project/
 | Old Command | New Command(s) | Purpose |
 | :--- | :--- | :--- |
 | `list-rules` | `rulebook-ai packs list` | Lists all available packs from the source repository. |
-| `install` | `rulebook-ai packs add <name>` | Adds a pack to the target project and runs `sync`. |
-| (n/a) | `rulebook-ai packs remove <name>` | Removes a pack and runs `sync`. |
-| (n/a) | `rulebook-ai packs status` | Shows the active packs and their order. |
-| `sync` | `rulebook-ai sync` | Regenerates all rules and starters from active packs. |
-| `clean-all` | `rulebook-ai clean` | Replaces `clean-all`, removing the `.rulebook-ai` dir and all generated content. |
+| `install` | `rulebook-ai packs add <name>` | Adds a pack to the target project and triggers an implicit `sync`. |
+| (n/a) | `rulebook-ai packs remove <name>` | Removes a pack and triggers an implicit `sync`. |
+| (n/a) | `rulebook-ai packs status` | Shows the active packs, their versions, and their order. |
+| `sync` | `rulebook-ai sync` | Regenerates all rules and starters from active packs. Supports `--strict` to fail on file conflicts *(optional, low priority)*, `--force` to overwrite on conflict *(optional, low priority)*, and `--rebuild` to purge `memory/` and `tools/` before copying *(optional, low priority)*. |
+| `clean-all` | `rulebook-ai clean` | Removes the `.rulebook-ai` dir, `memory/`, `tools/`, and generated rules (destructive). |
+| `clean-rules` | `rulebook-ai clean-rules` | Deletes `.rulebook-ai` and generated rules but preserves `memory/` and `tools`. |
 
 ## 6. Phase 4: Core Logic Refactoring (`src/rulebook_ai/core.py`)
 
@@ -98,25 +101,33 @@ your-target-project/
 2.  **Create `add_pack(pack_name)`:**
     *   Validates that the pack exists in the source `packs/` dir.
     *   Copies the pack source into the target's `.rulebook-ai/packs/`.
-    *   Appends the pack name to `.rulebook-ai/selection.json`.
-    *   Calls `self.sync()`.
+    *   Appends the pack's `name` and `version` to `.rulebook-ai/selection.json`.
+    *   Calls `self.sync()` in implicit mode to update existing assistant rules and merge `memory/` and `tools`.
 3.  **Create `remove_pack(pack_name)`:**
     *   Removes the pack from `selection.json`.
     *   Deletes the pack's source from `.rulebook-ai/packs/`.
-    *   Calls `self.sync()`.
+    *   Uses the per-pack file map to purge `memory/` and `tools` files owned by the pack.
+    *   Calls `self.sync()` in implicit mode.
 4.  **Heavily Refactor `sync()`:**
-    *   This is the core of the new logic.
+    *   Sync operates in two modes:
+        *   **Explicit** – user passes assistant flags (e.g., `--cursor`); only those assistants are regenerated.
+        *   **Implicit** – no flags; used by `add`/`remove` to rebuild rules only for assistants that already have rule directories.
     *   **Delete all existing generated platform rules** (using `assistants.py` spec).
-    *   Read the ordered list of pack names from `.rulebook-ai/selection.json`.
+    *   Read the ordered list of pack entries (name and version) from `.rulebook-ai/selection.json`.
     *   **Compose `memory/` and `tools/`:**
         *   Iterate through the active packs *in order*.
-        *   For each file in a pack's `memory_starters/` and `tool_starters/`, perform a **non-destructive copy** to the top-level `memory/` and `tools/`. The first pack to provide a file "wins."
+        *   For each file in a pack's `memory_starters/` and `tool_starters/`, perform a **non-destructive copy** to the top-level `memory/` and `tools/`. Record each copied path in `.rulebook-ai/packs/<pack>/file-map.json`.
+        *   The first pack to provide a file "wins." If a later pack contains a file that already exists, skip it and log a warning so users know which pack was ignored.
+        *   Support a `--strict` mode that aborts the sync when any such conflict is detected *(optional, low priority)*.
+        *   Support a `--force` flag that overwrites conflicting files from later packs *(optional, low priority)*.
+        *   Support a `--rebuild` flag that purges previously copied `memory/` and `tools` files before performing the copy *(optional, low priority)*.
     *   **Compose AI Rules:**
         *   Gather all rule files from the `rules/` directory of *every* active pack.
         *   Concatenate them into a single stream, respecting the order from `selection.json`.
         *   Generate the final, combined rule files for each selected AI assistant (e.g., `.cursor/rules/combined.md`).
-5.  **Refactor `clean_all()` to `clean()`:**
-    *   This method will now remove the entire `.rulebook-ai/` directory, `memory/`, `tools/`, and all generated platform rules. It must retain its safety confirmation prompt.
+5.  **Refactor `clean_all()` to `clean()` and add `clean_rules()`:**
+    *   `clean()` removes the entire `.rulebook-ai/` directory, `memory/`, `tools/`, and all generated platform rules. It must retain its safety confirmation prompt.
+    *   `clean_rules()` deletes only `.rulebook-ai/` and generated platform rules, preserving the top-level `memory/` and `tools/` directories.
 
 ## 7. Phase 5: CLI Refactoring (`src/rulebook_ai/cli.py`)
 
@@ -125,4 +136,8 @@ your-target-project/
 *   Create sub-parsers for the `packs` command group (`list`, `add`, `remove`, `status`).
 *   The `packs add` and `packs remove` commands will take a `pack_name` argument.
 *   The main handler will route subcommands to the new methods in `RuleManager` (`add_pack`, `remove_pack`, etc.).
+*   Expose both `clean` and `clean-rules` top-level commands, each prompting for confirmation before deleting files.
+*   Add a `--strict` option to `sync` that aborts on file conflicts *(optional, low priority)*; without it, sync emits warnings when later packs are skipped.
+*   Add a `--force` option to `sync` that overwrites conflicting files *(optional, low priority)*.
+*   Add a `--rebuild` option to `sync` that purges `memory/` and `tools/` before copying from active packs *(optional, low priority)*.
 *   The `--cursor`, `--cline`, etc. flags are no longer needed for `add`/`remove`, but should be kept for the `sync` command to allow targeted syncs for specific assistants.


### PR DESCRIPTION
## Summary
- document optional `--force` flag for `rulebook-ai sync` to overwrite conflicting files
- clarify conflict handling in core and CLI refactor sections
- reference shared `sync` flow in command diagrams to reduce duplication

## Testing
- `uv run pre-commit run --files memory/docs/features/manage_rules/command_flow_diagrams.md` *(fails: CalledProcessError: HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5d9eb984832f9c735d9042ce21f0