### PR TITLE
docs: update CLI spec and implementation design for composable packs

### DIFF
--- a/memory/docs/features/manage_rules/implementation_design.md
+++ b/memory/docs/features/manage_rules/implementation_design.md
@@ -2,23 +2,82 @@
 
 ## 1. High-Level Goal & Architecture
 
-The `rulebook-ai` CLI is designed to be maintainable and extensible. The core implementation follows a clean **separation of concerns**, splitting the logic into two distinct parts:
+The refactored CLI lets users compose multiple modular **Packs** inside one project while still keeping the codebase easy to maintain. It preserves a **separation of concerns**:
 
-1.  **A declarative configuration (`assistants.py`)**: This file defines the *specification* for each AI assistant—what they expect to find on the filesystem—using a pure, data-only `AssistantSpec` class. It is the single source of truth for all assistant-specific information.
-2.  **A generic engine (`core.py`)**: The `RuleManager` class acts as a generic engine that reads the assistant specifications and performs the necessary file operations (copying, cleaning, generating rules). It contains all the logic for *how* to generate rules based on the specifications.
+1. **Declarative configuration (`assistants.py`)** – describes how each supported assistant expects its rules to be laid out on disk. Adding a new assistant remains a matter of adding a new spec.
+2. **Generic engine (`core.py`)** – interprets those specs and carries out filesystem operations such as copying, syncing, and cleaning. The engine now manages multiple packs rather than a single rule set.
 
-This architecture makes adding a new assistant a simple matter of adding a new entry to the configuration file, without touching the core engine logic.
+### Key Directories in a Target Project
+
+| Path | Purpose |
+|------|---------|
+| `.rulebook-ai/` | Hidden internal state. Holds per-pack copies under `.rulebook-ai/packs/<pack>/` and a machine-readable `selection.json` recording the active pack list and order. |
+| `memory/` | User-owned unified memory bank. Populated from pack `memory_starters/` and intended for version control. |
+| `tools/` | User-owned unified tools directory. Populated from pack `tool_starters/` and intended for version control. |
+| *Assistant rule dirs* | Generated platform rules (e.g., `.cursor/`, `.clinerules/`, `WARP.md`). Should be gitignored. |
+
+Earlier packs in `selection.json` take precedence when files conflict; later packs are skipped unless the user opts into `--force` or `--strict` behaviors.
 
 ## 2. Code Structure
 
--   **`src/rulebook_ai/cli.py`**: Handles command-line argument parsing using Python's `argparse` library. It dynamically generates CLI flags (e.g., `--cursor`, `--cline`) from the `SUPPORTED_ASSISTANTS` list in `assistants.py`. It then calls the appropriate methods in the `RuleManager`.
--   **`src/rulebook_ai/core.py`**: Contains the `RuleManager` class, which implements the main business logic for the `install`, `sync`, `clean-rules`, and `clean-all` commands.
--   **`src/rulebook_ai/assistants.py`**: Contains the `AssistantSpec` dataclass and the `SUPPORTED_ASSISTANTS` list, which provides the specifications for all supported AI assistants.
+### `src/rulebook_ai/assistants.py`
+Declarative definitions of supported assistants using an `AssistantSpec` dataclass. Each spec describes how rule files are laid out on disk.
+
+### `src/rulebook_ai/core.py`
+Home of the `RuleManager` class. Key responsibilities:
+
+- `list_packs()` – enumerate available packs from the source repo.
+- `add_pack(name)` – copy a pack into `.rulebook-ai/packs/`, refresh if it already exists, append to `selection.json`, merge starter `memory/` and `tools` without overwriting existing files, then trigger an implicit sync.
+- `remove_pack(name)` – drop a pack from `selection.json`, delete its copy under `.rulebook-ai/packs/`, remove starter files it introduced, then trigger an implicit sync.
+- `sync(assistants=None, strict=False, force=False, rebuild=False)` – regenerate assistant rules and compose `memory/`/`tools` from active packs. Supports explicit invocation (user runs `sync`) and implicit invocation (called from `add_pack`/`remove_pack`).
+- `clean()` – remove `.rulebook-ai/`, `memory/`, `tools/`, and all generated rule directories after confirmation.
+- `clean_rules()` – remove `.rulebook-ai/` and generated rule directories while preserving `memory/` and `tools`.
+- `status()` – read `selection.json` and report the active pack list and order.
+
+The class reads each pack's `manifest.yaml` and maintains a `file-map.json` per pack to track which starter files were copied.
+
+### `src/rulebook_ai/cli.py`
+Argument parsing and user interaction via `argparse`:
+
+- Provides a `packs` command group with `list`, `add <name>`, `remove <name>`, and `status` subcommands.
+- Exposes top-level `sync`, `clean`, and `clean-rules` commands.
+- Dynamically generates assistant flags (`--cursor`, `--cline`, etc.) from `SUPPORTED_ASSISTANTS` for the `sync` command.
+- Prints progress messages and helpful commit/ignore hints after operations.
 
 ## 3. Core Implementation Notes
 
--   **Path Handling:** The implementation must use robust path handling to manage files and directories across different operating systems.
--   **User Feedback:** The CLI should provide clear and concise feedback to the user for all operations.
--   **Hardcoded Constants:** Directory names for the framework components (e.g., `rule_sets` in the source repo, `project_rules`, `memory`, `tools` in the target repo) are hardcoded as constants within the script for simplicity and reliability.
--   **Parent Directory Creation:** Helper functions that write files (e.g., for `copilot-instructions.md` or `GEMINI.md`) must ensure that the parent directories (`.github/`, `.gemini/`) are created if they do not exist.
--   **Extensibility for Assistants:** The `AssistantSpec` is designed to be extensible. For example, the `has_modes` flag was added to support assistants like Kilo Code and Roo Code, which use subdirectories for different modes. The `RuleManager`'s generation logic was extended to interpret this flag.
+- **Explicit state:** `selection.json` is the source of truth for which packs are active and in what order. All operations read and update this file.
+- **Pack refresh:** `add_pack` always clears and overwrites any existing copy of the pack in `.rulebook-ai/packs/<pack>/` to ensure freshness.
+- **Conflict handling:** When composing `memory/` and `tools`, earlier packs win. Later packs encountering existing files are skipped with a warning. `--strict` aborts on conflict; `--force` overwrites.
+- **Implicit vs. explicit sync:** `sync` regenerates assistant rules and merges starter files. Explicit sync is invoked directly by the user and may target specific assistants. Implicit sync is automatically run after `add_pack` or `remove_pack`.
+- **Path handling:** The implementation must use robust path handling to manage files and directories across different operating systems.
+- **User feedback:** The CLI should provide clear and concise feedback to the user for all operations.
+- **Hardcoded constants:** Directory names for framework components (e.g., `rule_sets` in the source repo, `memory`, `tools` in the target repo) are hardcoded as constants within the script for simplicity and reliability.
+- **Parent directory creation:** Helper functions that write files (e.g., for `copilot-instructions.md` or `GEMINI.md`) must ensure that the parent directories (`.github/`, `.gemini/`) are created if they do not exist.
+- **Extensibility for assistants:** The `AssistantSpec` is designed to be extensible. For example, the `has_modes` flag supports assistants like Kilo Code and Roo Code, which use subdirectories for different modes.
+
+## 4. Typical Workflows
+
+1. **Start a project**
+   - `rulebook-ai packs add light-spec`
+   - Commit `memory/`, `tools/`, and relevant `.gitignore` updates.
+
+2. **Compose personas**
+   - `rulebook-ai packs add python-data-scientist`
+   - `rulebook-ai packs status`
+
+3. **Regenerate rules after manual edits**
+   - Modify files in `memory/` or `tools/`.
+   - `rulebook-ai sync --cursor`
+
+4. **Remove a pack**
+   - `rulebook-ai packs remove python-data-scientist`
+   - Commit resulting changes to `memory/`, `tools`, and generated rules.
+
+5. **Reset generated rules only**
+   - `rulebook-ai clean-rules`
+
+6. **Full uninstall**
+   - `rulebook-ai clean`
+
+These workflows mirror the CLI behaviors documented in `spec.md` while highlighting how the underlying components cooperate.

--- a/memory/docs/features/manage_rules/task_plan.md
+++ b/memory/docs/features/manage_rules/task_plan.md
@@ -1,14 +1,82 @@
-# Task Plan: Manage Rules Feature
+# Task Plan: Manage Rules Feature (Composable Packs)
 
 ## 🎯 Goal
 
-This document tracks the development tasks for the "Manage Rules" feature of the `rulebook-ai` CLI.
+Track the implementation work required to migrate the CLI to the composable Pack architecture.
 
 ---
 
-### General Tasks
+### Phase 0: Documentation Baseline
 
-| Task ID | Description                                                                              | Importance | Status      | Dependencies      |
-|:--------|:-----------------------------------------------------------------------------------------|:-----------|:------------|:------------------|
-| **T1**  | Refactor the feature documentation to separate the specification, implementation, and task planning. | P1         | Completed   | -                 |
-| **T2**  | *(Placeholder for next feature enhancement or bug fix)*                                  | P_         | To Do       | -                 |
+**Description:** Establish clear specification and design references.
+
+| Task ID | Description | Importance | Status | Dependencies |
+|:--------|:------------|:-----------|:-------|:-------------|
+| **0.1** | Consolidate pack-based CLI spec in `spec.md`. | P0 | Completed | - |
+| **0.2** | Document implementation design and workflows in `implementation_design.md`. | P0 | Completed | 0.1 |
+| **0.3** | Finalize phased implementation roadmap in `support_flexible_ruleset_plan.md`. | P0 | Completed | 0.2 |
+
+### Phase 1: Source Repository Restructuring
+
+**Description:** Move legacy assets into a `packs/` directory with per-pack metadata.
+
+| Task ID | Description | Importance | Status | Dependencies |
+|:--------|:------------|:-----------|:-------|:-------------|
+| **1.1** | Create top-level `packs/` directory and migrate existing `rule_sets`, `memory_starters`, and `tool_starters`. | P1 | To Do | 0.3 |
+| **1.2** | Add `manifest.yaml` for each pack recording name, version, and summary. | P1 | To Do | 1.1 |
+| **1.3** | Provide `README.md` in each pack describing its purpose. | P3 | To Do | 1.2 |
+
+### Phase 2: Target Project Structure
+
+**Description:** Establish hidden state and persistent context directories in user projects.
+
+| Task ID | Description | Importance | Status | Dependencies |
+|:--------|:------------|:-----------|:-------|:-------------|
+| **2.1** | Initialize `.rulebook-ai/` directory with per-pack copies and machine-readable `selection.json`. | P0 | To Do | 1.1 |
+| **2.2** | Ensure `memory/` and `tools/` directories are created and tracked under version control. | P0 | To Do | 2.1 |
+| **2.3** | Maintain per-pack `file-map.json` to track starter files for clean removal. | P1 | To Do | 2.1 |
+
+### Phase 3: CLI Command Evolution
+
+**Description:** Replace legacy rule-set commands with a pack-focused interface.
+
+| Task ID | Description | Importance | Status | Dependencies |
+|:--------|:------------|:-----------|:-------|:-------------|
+| **3.1** | Implement `rulebook-ai packs list` showing pack name, version, and description. | P0 | To Do | 1.2 |
+| **3.2** | Implement `packs add <name>` with implicit sync and refresh of existing pack copy. | P0 | To Do | 2.1 |
+| **3.3** | Implement `packs remove <name>` with implicit sync and cleanup of starter files. | P0 | To Do | 2.3 |
+| **3.4** | Implement `packs status` to display active packs in order. | P1 | To Do | 2.1 |
+| **3.5** | Update `sync` command with `--strict`, `--force`, and `--rebuild` options. | P2 | To Do | 3.2 |
+| **3.6** | Add `clean` and `clean-rules` commands with safety prompts. | P2 | To Do | 2.1 |
+
+### Phase 4: Core Logic Refactoring
+
+**Description:** Extend `RuleManager` to manage packs and compose outputs.
+
+| Task ID | Description | Importance | Status | Dependencies |
+|:--------|:------------|:-----------|:-------|:-------------|
+| **4.1** | Add `list_packs`, `add_pack`, `remove_pack`, and `status` methods. | P0 | To Do | 3.1 |
+| **4.2** | Refactor `sync()` for explicit and implicit modes, conflict handling, and per-pack precedence. | P0 | To Do | 3.5 |
+| **4.3** | Implement `clean()` and `clean_rules()` aligned with new state layout. | P1 | To Do | 4.1 |
+| **4.4** | Read `manifest.yaml` and maintain per-pack file maps. | P1 | To Do | 4.1 |
+
+### Phase 5: CLI Refactoring
+
+**Description:** Wire argument parsing and handlers to the new core logic.
+
+| Task ID | Description | Importance | Status | Dependencies |
+|:--------|:------------|:-----------|:-------|:-------------|
+| **5.1** | Create `packs` subparsers (`list`, `add`, `remove`, `status`). | P0 | To Do | 3.1 |
+| **5.2** | Expose `sync` assistant flags and options from `SUPPORTED_ASSISTANTS`. | P1 | To Do | 4.2 |
+| **5.3** | Expose top-level `clean` and `clean-rules` commands. | P1 | To Do | 4.3 |
+| **5.4** | Provide clear progress messages and commit/ignore hints. | P3 | To Do | 5.1 |
+
+### Phase 6: Testing & Documentation
+
+**Description:** Validate behavior and keep documentation current.
+
+| Task ID | Description | Importance | Status | Dependencies |
+|:--------|:------------|:-----------|:-------|:-------------|
+| **6.1** | Add integration tests for pack workflows (`add`, `remove`, `sync`). | P0 | To Do | 5.1 |
+| **6.2** | Update unit tests for `RuleManager` pack logic. | P0 | To Do | 4.2 |
+| **6.3** | Document workflows and examples in README and feature docs. | P1 | To Do | 6.1 |


### PR DESCRIPTION
## Summary
- rewrite CLI specification to describe composable Pack model and pack management commands
- add implementation design detailing architecture, core responsibilities, and typical workflows for pack-based system
- outline phased task plan for implementing composable packs

## Testing
- no tests run

context docs: 
memory/docs/features/manage_rules/support_flexible_ruleset_plan.md


------
https://chatgpt.com/codex/tasks/task_e_68bb1a7b302c832fb57bc998703f5aa1