### PR TITLE
test: ensure community_packs module import

### DIFF
--- a/tests/integration/test_package_installation.py
+++ b/tests/integration/test_package_installation.py
@@ -27,6 +27,13 @@ def test_cli_module_import():
     print("✅ Successfully imported CLI module")
 
 
+def test_community_packs_module_import():
+    """Test that community_packs module can be imported."""
+    from rulebook_ai import community_packs
+    assert hasattr(community_packs, 'validate_pack_structure')
+    print("✅ Successfully imported community_packs module")
+
+
 def test_rule_manager_instantiation():
     """Test that RuleManager can be instantiated."""
     from rulebook_ai.core import RuleManager
@@ -45,7 +52,7 @@ def test_package_structure():
     import inspect
     
     # Check that main modules exist
-    expected_modules = ['core', 'cli']
+    expected_modules = ['core', 'cli', 'community_packs']
     
     for module_name in expected_modules:
         try:


### PR DESCRIPTION
## Summary
- verify `rulebook_ai.community_packs` can be imported in integration tests
- assert `community_packs` exists in package module structure

## Testing
- `pytest tests/integration/test_package_installation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4b84ff5d0832f97b04637508b26eb