### PR TITLE
feat: add assistant selection flag

### DIFF
--- a/src/rulebook_ai/cli.py
+++ b/src/rulebook_ai/cli.py
@@ -83,14 +83,14 @@ def create_parser() -> argparse.ArgumentParser:
     sync_parser.add_argument("--profile")
     sync_parser.add_argument("--pack", action="append", dest="packs")
     assist_group = sync_parser.add_argument_group("assistant selection")
-    for assistant in SUPPORTED_ASSISTANTS:
-        assist_group.add_argument(
-            f"--{assistant.name}",
-            action="append_const",
-            dest="assistants",
-            const=assistant.name,
-            help=f"Generate rules for {assistant.display_name}",
-        )
+    assist_group.add_argument(
+        "--assistant",
+        "-a",
+        dest="assistants",
+        nargs="+",
+        choices=[a.name for a in SUPPORTED_ASSISTANTS],
+        help="Generate rules for selected assistant(s)",
+    )
     assist_group.add_argument(
         "--all",
         action="store_const",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,5 +26,5 @@ def synced_project(tmp_path, run_cli):
     project_dir = tmp_path / "proj"
     project_dir.mkdir()
     run_cli(["packs", "add", "light-spec"], project_dir)
-    run_cli(["project", "sync", "--cursor"], project_dir)
+    run_cli(["project", "sync", "--assistant", "cursor"], project_dir)
     return project_dir

--- a/tests/integration/test_packs_management.py
+++ b/tests/integration/test_packs_management.py
@@ -40,7 +40,7 @@ def test_remove_pack_does_not_touch_context(tmp_path, run_cli):
     project_dir.mkdir()
 
     run_cli(["packs", "add", "light-spec"], project_dir)
-    run_cli(["project", "sync", "--cursor"], project_dir)
+    run_cli(["project", "sync", "--assistant", "cursor"], project_dir)
     assert (project_dir / "memory" / "docs" / "architecture_template.md").is_file()
     assert (project_dir / "tools" / "web_scraper.py").is_file()
 

--- a/tests/integration/test_profiles.py
+++ b/tests/integration/test_profiles.py
@@ -16,7 +16,10 @@ def test_profile_creation_and_sync(tmp_path, run_cli):
     list_out = run_cli(["profiles", "list"], project_dir)
     assert "frontend" in list_out.stdout
 
-    result = run_cli(["project", "sync", "--profile", "frontend", "--cursor"], project_dir)
+    result = run_cli(
+        ["project", "sync", "--profile", "frontend", "--assistant", "cursor"],
+        project_dir,
+    )
     assert result.returncode == 0
 
     status = json.loads(

--- a/tests/integration/test_project_sync.py
+++ b/tests/integration/test_project_sync.py
@@ -9,7 +9,7 @@ def test_project_sync_with_pack_flag(tmp_path, run_cli):
     assert run_cli(["packs", "add", "heavy-spec"], project_dir).returncode == 0
 
     result = run_cli(
-        ["project", "sync", "--pack", "light-spec", "--cursor"], project_dir
+        ["project", "sync", "--pack", "light-spec", "--assistant", "cursor"], project_dir
     )
     assert result.returncode == 0, result.stderr
 
@@ -37,7 +37,7 @@ def test_project_sync_all_packs(tmp_path, run_cli):
 
     run_cli(["packs", "add", "light-spec", "heavy-spec"], project_dir)
 
-    result = run_cli(["project", "sync", "--cursor"], project_dir)
+    result = run_cli(["project", "sync", "--assistant", "cursor"], project_dir)
     assert result.returncode == 0, result.stderr
     manifest = json.loads(
         (project_dir / ".rulebook-ai" / "file_manifest.json").read_text()
@@ -56,7 +56,10 @@ def test_project_sync_with_profile(tmp_path, run_cli):
     run_cli(["profiles", "create", "frontend"], project_dir)
     run_cli(["profiles", "add", "light-spec", "--to", "frontend"], project_dir)
 
-    result = run_cli(["project", "sync", "--profile", "frontend", "--cursor"], project_dir)
+    result = run_cli(
+        ["project", "sync", "--profile", "frontend", "--assistant", "cursor"],
+        project_dir,
+    )
     assert result.returncode == 0, result.stderr
 
     manifest = json.loads(
@@ -74,8 +77,11 @@ def test_project_status_reports_last_sync(tmp_path, run_cli):
     project_dir.mkdir()
 
     run_cli(["packs", "add", "light-spec"], project_dir)
-    run_cli(["project", "sync", "--cursor"], project_dir)
-    run_cli(["project", "sync", "--windsurf", "--pack", "light-spec"], project_dir)
+    run_cli(["project", "sync", "--assistant", "cursor"], project_dir)
+    run_cli(
+        ["project", "sync", "--assistant", "windsurf", "--pack", "light-spec"],
+        project_dir,
+    )
 
     out = run_cli(["project", "status"], project_dir)
     assert "cursor" in out.stdout and "all" in out.stdout


### PR DESCRIPTION
## Summary
- add `--assistant` option to `project sync`
- update integration tests for new CLI flag

## Testing
- `pytest tests/integration -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4c590fd14832faeb04538f3a8792a